### PR TITLE
Fixed opening a cmd in another drive

### DIFF
--- a/lib/code.coffee
+++ b/lib/code.coffee
@@ -20,4 +20,4 @@ module.exports =
     else
       dir_path = select_file
 
-    exec "start cmd /k \"cd \"#{dir_path}\"\""
+    exec "start cmd /k \"cd /d \"#{dir_path}\"\""


### PR DESCRIPTION
This fixes opening a directory in a drive different from the drive where atom is installed.
